### PR TITLE
Sync juju legend libs

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -18,6 +18,14 @@ options:
       String identifier of the log level to be used for incoming requests.
       Must be one of INFO, WARN, DEBUG, or TRACE, or OFF.
 
+  ### Nginx Ingress Integrator-related options:
+  external-hostname:
+    type: string
+    default: ""
+    description: |
+      String representing the DNS name this Application should respond to.
+      By default, this will be the Application's name.
+
   ### Gitlab-related options:
   gitlab-create-new-projects-as-public:
     type: boolean

--- a/lib/charms/finos_legend_libs/v0/legend_operator_base.py
+++ b/lib/charms/finos_legend_libs/v0/legend_operator_base.py
@@ -13,6 +13,7 @@ import jks
 from charms.finos_legend_db_k8s.v0 import legend_database
 from charms.finos_legend_gitlab_integrator_k8s.v0 import legend_gitlab
 from charms.nginx_ingress_integrator.v0 import ingress
+from charms.observability_libs.v0 import kubernetes_service_patch as k8s_svc_patch
 from OpenSSL import crypto
 from ops import charm, framework, model
 
@@ -24,7 +25,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 2
+LIBPATCH = 3
 
 logger = logging.getLogger(__name__)
 
@@ -179,12 +180,19 @@ class BaseFinosLegendCharm(charm.CharmBase):
 
         self._set_stored_defaults()
 
-        # TODO(aznashwan): worth always setting up an ingress for all services?
+        svc_hostname = self.model.config["external-hostname"] or self.app.name
         self.ingress = ingress.IngressRequires(
             self, {
-                "service-hostname": self.app.name,
+                "service-hostname": svc_hostname,
                 "service-name": self.app.name,
                 "service-port": self._get_application_connector_port()})
+
+        self.service_patcher = k8s_svc_patch.KubernetesServicePatch(
+            self,
+            [
+                (f"{self.app.name}", 80, self._get_application_connector_port()),
+            ],
+        )
 
         # Standard charm lifecycle events:
         self.framework.observe(
@@ -549,6 +557,9 @@ class BaseFinosLegendCharm(charm.CharmBase):
 
     def _on_config_changed(self, event: charm.ConfigChangedEvent):
         """Refreshes the service config."""
+        # TODO(claudiub): Update the SDLC and Engine relations with the new Service URL.
+        svc_hostname = self.model.config["external-hostname"] or self.app.name
+        self.ingress.update_config({"service-hostname": svc_hostname})
         self._refresh_charm_status()
 
     def _on_workload_container_pebble_ready(
@@ -567,6 +578,7 @@ class BaseFinosLegendCharm(charm.CharmBase):
         # if all the relations are present and write the configs itself:
         # container.autostart()
 
+        self._update_gitlab_relation_callback_uris()
         self._refresh_charm_status()
 
 
@@ -584,6 +596,9 @@ class BaseFinosLegendCoreServiceCharm(BaseFinosLegendCharm):
         super().__init__(*args)
 
         self._set_stored_defaults()
+
+        # Standard charm lifecycle events:
+        self.framework.observe(self.on.upgrade_charm, self._on_upgrade_charm)
 
         # Get relation names:
         legend_db_relation_name = self._get_legend_db_relation_name()
@@ -709,6 +724,18 @@ class BaseFinosLegendCoreServiceCharm(BaseFinosLegendCharm):
 
         return self._get_core_legend_service_configs(
             legend_db_credentials, legend_gitlab_credentials)
+
+    def _update_gitlab_relation_callback_uris(self):
+        relation = self._get_relation(self._get_legend_gitlab_relation_name())
+        if not relation:
+            return
+
+        redirect_uris = self._get_legend_gitlab_redirect_uris()
+        legend_gitlab.set_legend_gitlab_redirect_uris_in_relation_data(
+            relation.data[self.app], redirect_uris)
+
+    def _on_upgrade_charm(self, _: charm.UpgradeCharmEvent) -> None:
+        self._update_gitlab_relation_callback_uris()
 
     def _on_db_relation_joined(
             self, _: charm.RelationJoinedEvent) -> None:

--- a/lib/charms/observability_libs/v0/kubernetes_service_patch.py
+++ b/lib/charms/observability_libs/v0/kubernetes_service_patch.py
@@ -1,0 +1,280 @@
+# Copyright 2021 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""# KubernetesServicePatch Library.
+
+This library is designed to enable developers to more simply patch the Kubernetes Service created
+by Juju during the deployment of a sidecar charm. When sidecar charms are deployed, Juju creates a
+service named after the application in the namespace (named after the Juju model). This service by
+default contains a "placeholder" port, which is 65536/TCP.
+
+When modifying the default set of resources managed by Juju, one must consider the lifecycle of the
+charm. In this case, any modifications to the default service (created during deployment), will
+be overwritten during a charm upgrade.
+
+When initialised, this library binds a handler to the parent charm's `install` and `upgrade_charm`
+events which applies the patch to the cluster. This should ensure that the service ports are
+correct throughout the charm's life.
+
+The constructor simply takes a reference to the parent charm, and a list of tuples that each define
+a port for the service, where each tuple contains:
+
+- a name for the port
+- port for the service to listen on
+- optionally: a targetPort for the service (the port in the container!)
+- optionally: a nodePort for the service (for NodePort or LoadBalancer services only!)
+- optionally: a name of the service (in case service name needs to be patched as well)
+
+## Getting Started
+
+To get started using the library, you just need to fetch the library using `charmcraft`. **Note
+that you also need to add `lightkube` and `lightkube-models` to your charm's `requirements.txt`.**
+
+```shell
+cd some-charm
+charmcraft fetch-lib charms.observability_libs.v0.kubernetes_service_patch
+echo <<-EOF >> requirements.txt
+lightkube
+lightkube-models
+EOF
+```
+
+Then, to initialise the library:
+
+For ClusterIP services:
+```python
+# ...
+from charms.observability_libs.v0.kubernetes_service_patch import KubernetesServicePatch
+
+class SomeCharm(CharmBase):
+  def __init__(self, *args):
+    # ...
+    self.service_patcher = KubernetesServicePatch(self, [(f"{self.app.name}", 8080)])
+    # ...
+```
+
+For LoadBalancer/NodePort services:
+```python
+# ...
+from charms.observability_libs.v0.kubernetes_service_patch import KubernetesServicePatch
+
+class SomeCharm(CharmBase):
+  def __init__(self, *args):
+    # ...
+    self.service_patcher = KubernetesServicePatch(
+        self, [(f"{self.app.name}", 443, 443, 30666)], "LoadBalancer"
+    )
+    # ...
+```
+
+Additionally, you may wish to use mocks in your charm's unit testing to ensure that the library
+does not try to make any API calls, or open any files during testing that are unlikely to be
+present, and could break your tests. The easiest way to do this is during your test `setUp`:
+
+```python
+# ...
+
+@patch("charm.KubernetesServicePatch", lambda x, y: None)
+def setUp(self, *unused):
+    self.harness = Harness(SomeCharm)
+    # ...
+```
+"""
+
+import logging
+from types import MethodType
+from typing import Literal, Sequence, Tuple, Union
+
+from lightkube import ApiError, Client
+from lightkube.models.core_v1 import ServicePort, ServiceSpec
+from lightkube.models.meta_v1 import ObjectMeta
+from lightkube.resources.core_v1 import Service
+from lightkube.types import PatchType
+from ops.charm import CharmBase
+from ops.framework import Object
+
+logger = logging.getLogger(__name__)
+
+# The unique Charmhub library identifier, never change it
+LIBID = "0042f86d0a874435adef581806cddbbb"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 0
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 6
+
+PortDefinition = Union[Tuple[str, int], Tuple[str, int, int], Tuple[str, int, int, int]]
+ServiceType = Literal["ClusterIP", "LoadBalancer"]
+
+
+class KubernetesServicePatch(Object):
+    """A utility for patching the Kubernetes service set up by Juju."""
+
+    def __init__(
+        self,
+        charm: CharmBase,
+        ports: Sequence[PortDefinition],
+        service_name: str = None,
+        service_type: ServiceType = "ClusterIP",
+        additional_labels: dict = None,
+        additional_selectors: dict = None,
+        additional_annotations: dict = None,
+    ):
+        """Constructor for KubernetesServicePatch.
+
+        Args:
+            charm: the charm that is instantiating the library.
+            ports: a list of tuples (name, port, targetPort, nodePort) for every service port.
+            service_name: allows setting custom name to the patched service. If none given,
+                application name will be used.
+            service_type: desired type of K8s service. Default value is in line with ServiceSpec's
+                default value.
+            additional_labels: Labels to be added to the kubernetes service (by default only
+                "app.kubernetes.io/name" is set to the service name)
+            additional_selectors: Selectors to be added to the kubernetes service (by default only
+                "app.kubernetes.io/name" is set to the service name)
+            additional_annotations: Annotations to be added to the kubernetes service.
+        """
+        super().__init__(charm, "kubernetes-service-patch")
+        self.charm = charm
+        self.service_name = service_name if service_name else self._app
+        self.service = self._service_object(
+            ports,
+            service_name,
+            service_type,
+            additional_labels,
+            additional_selectors,
+            additional_annotations,
+        )
+
+        # Make mypy type checking happy that self._patch is a method
+        assert isinstance(self._patch, MethodType)
+        # Ensure this patch is applied during the 'install' and 'upgrade-charm' events
+        self.framework.observe(charm.on.install, self._patch)
+        self.framework.observe(charm.on.upgrade_charm, self._patch)
+
+    def _service_object(
+        self,
+        ports: Sequence[PortDefinition],
+        service_name: str = None,
+        service_type: ServiceType = "ClusterIP",
+        additional_labels: dict = None,
+        additional_selectors: dict = None,
+        additional_annotations: dict = None,
+    ) -> Service:
+        """Creates a valid Service representation.
+
+        Args:
+            ports: a list of tuples of the form (name, port) or (name, port, targetPort)
+                or (name, port, targetPort, nodePort) for every service port. If the 'targetPort'
+                is omitted, it is assumed to be equal to 'port', with the exception of NodePort
+                and LoadBalancer services, where all port numbers have to be specified.
+            service_name: allows setting custom name to the patched service. If none given,
+                application name will be used.
+            service_type: desired type of K8s service. Default value is in line with ServiceSpec's
+                default value.
+            additional_labels: Labels to be added to the kubernetes service (by default only
+                "app.kubernetes.io/name" is set to the service name)
+            additional_selectors: Selectors to be added to the kubernetes service (by default only
+                "app.kubernetes.io/name" is set to the service name)
+            additional_annotations: Annotations to be added to the kubernetes service.
+
+        Returns:
+            Service: A valid representation of a Kubernetes Service with the correct ports.
+        """
+        if not service_name:
+            service_name = self._app
+        labels = {"app.kubernetes.io/name": self._app}
+        if additional_labels:
+            labels.update(additional_labels)
+        selector = {"app.kubernetes.io/name": self._app}
+        if additional_selectors:
+            selector.update(additional_selectors)
+        return Service(
+            apiVersion="v1",
+            kind="Service",
+            metadata=ObjectMeta(
+                namespace=self._namespace,
+                name=service_name,
+                labels=labels,
+                annotations=additional_annotations,  # type: ignore[arg-type]
+            ),
+            spec=ServiceSpec(
+                selector=selector,
+                ports=[
+                    ServicePort(
+                        name=p[0],
+                        port=p[1],
+                        targetPort=p[2] if len(p) > 2 else p[1],  # type: ignore[misc]
+                        nodePort=p[3] if len(p) > 3 else None,  # type: ignore[arg-type, misc]
+                    )
+                    for p in ports
+                ],
+                type=service_type,
+            ),
+        )
+
+    def _patch(self, _) -> None:
+        """Patch the Kubernetes service created by Juju to map the correct port.
+
+        Raises:
+            PatchFailed: if patching fails due to lack of permissions, or otherwise.
+        """
+        if not self.charm.unit.is_leader():
+            return
+
+        client = Client()
+        try:
+            if self.service_name != self._app:
+                self._delete_and_create_service(client)
+            client.patch(Service, self.service_name, self.service, patch_type=PatchType.MERGE)
+        except ApiError as e:
+            if e.status.code == 403:
+                logger.error("Kubernetes service patch failed: `juju trust` this application.")
+            else:
+                logger.error("Kubernetes service patch failed: %s", str(e))
+        else:
+            logger.info("Kubernetes service '%s' patched successfully", self._app)
+
+    def _delete_and_create_service(self, client: Client):
+        service = client.get(Service, self._app, namespace=self._namespace)
+        service.metadata.name = self.service_name  # type: ignore[attr-defined]
+        service.metadata.resourceVersion = service.metadata.uid = None  # type: ignore[attr-defined]   # noqa: E501
+        client.delete(Service, self._app, namespace=self._namespace)
+        client.create(service)
+
+    def is_patched(self) -> bool:
+        """Reports if the service patch has been applied.
+
+        Returns:
+            bool: A boolean indicating if the service patch has been applied.
+        """
+        client = Client()
+        # Get the relevant service from the cluster
+        service = client.get(Service, name=self.service_name, namespace=self._namespace)
+        # Construct a list of expected ports, should the patch be applied
+        expected_ports = [(p.port, p.targetPort) for p in self.service.spec.ports]
+        # Construct a list in the same manner, using the fetched service
+        fetched_ports = [(p.port, p.targetPort) for p in service.spec.ports]  # type: ignore[attr-defined]  # noqa: E501
+        return expected_ports == fetched_ports
+
+    @property
+    def _app(self) -> str:
+        """Name of the current Juju application.
+
+        Returns:
+            str: A string containing the name of the current Juju application.
+        """
+        return self.charm.app.name
+
+    @property
+    def _namespace(self) -> str:
+        """The Kubernetes namespace we're running in.
+
+        Returns:
+            str: A string containing the name of the current Kubernetes namespace.
+        """
+        with open("/var/run/secrets/kubernetes.io/serviceaccount/namespace", "r") as f:
+            return f.read().strip()

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ git+https://github.com/canonical/operator.git
 pyjks
 pyOpenSSL
 PyYAML
+lightkube
+lightkube-models

--- a/tests/test_charm.py
+++ b/tests/test_charm.py
@@ -73,3 +73,6 @@ class LegendSdlcTestCase(legend_operator_testing.TestBaseFinosCoreServiceLegendC
             rel.data[self.harness.charm.app],
             {"legend-sdlc-url": self.harness.charm._get_sdlc_service_url()},
         )
+
+    def test_upgrade_charm(self):
+        self._test_upgrade_charm()


### PR DESCRIPTION
Adds the ``observability_libs/v0/kubernetes_service_patch`` library. We're using this library to patch the Kubernetes Service created for the Finos Legend Applications.

Updates the ``legend-juju-libs`` library. The new updates include the following:

- upgrade charm relation event handled, which will allow us to update the callback URLs into the gitlab relation.
- Kubernetes Service Patch lib usage, which will allow us to use them instead of using IPs to connect to them, or the Studio having to rely on ephemeral IPs to connect to the SDLC and Engine Applications.

Adds unit test for the Upgrade Charm Event case.

Adds the ``external-hostname`` config option. If not set, the Application name will be used instead.