### PR TITLE
Updates SDLC service url to a name

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -18,7 +18,7 @@ LEGEND_DB_RELATION_NAME = "legend-db"
 LEGEND_GITLAB_RELATION_NAME = "legend-sdlc-gitlab"
 LEGEND_STUDIO_RELATION_NAME = "legend-sdlc"
 
-SDLC_SERVICE_URL_FORMAT = "%(schema)s://%(host)s:%(port)s%(path)s"
+SDLC_SERVICE_URL_FORMAT = "%(schema)s://%(host)s%(path)s"
 SDLC_CONFIG_FILE_CONTAINER_LOCAL_PATH = "/sdlc-config.yaml"
 SDLC_MAIN_GITLAB_REDIRECT_URL = "%(base_url)s/auth/callback"
 SDLC_GITLAB_REDIRECT_URI_FORMATS = [
@@ -127,13 +127,12 @@ class LegendSDLCServerCharm(legend_operator_base.BaseFinosLegendCoreServiceCharm
         return LEGEND_DB_RELATION_NAME
 
     def _get_sdlc_service_url(self):
-        ip_address = legend_operator_base.get_ip_address()
+        svc_hostname = self.model.config["external-hostname"] or self.app.name
         return SDLC_SERVICE_URL_FORMAT % (
             {
                 # NOTE(aznashwan): we always return the plain HTTP endpoint:
                 "schema": "http",
-                "host": ip_address,
-                "port": APPLICATION_CONNECTOR_PORT_HTTP,
+                "host": svc_hostname,
                 "path": APPLICATION_ROOT_PATH,
             }
         )

--- a/tests/test_charm.py
+++ b/tests/test_charm.py
@@ -76,3 +76,21 @@ class LegendSdlcTestCase(legend_operator_testing.TestBaseFinosCoreServiceLegendC
 
     def test_upgrade_charm(self):
         self._test_upgrade_charm()
+
+    def test_get_sdlc_service_url(self):
+        self.harness.set_leader(True)
+        self.harness.begin_with_initial_hooks()
+
+        # Test without external-hostname config.
+        actual_url = self.harness.charm._get_sdlc_service_url()
+
+        expected_url = "http://%s%s" % (self.harness.charm.app.name, charm.APPLICATION_ROOT_PATH)
+        self.assertEqual(expected_url, actual_url)
+
+        # Test with external-hostname config.
+        hostname = "foo.lish"
+        self.harness.update_config({"external-hostname": hostname})
+        actual_url = self.harness.charm._get_sdlc_service_url()
+
+        expected_url = "http://%s%s" % (hostname, charm.APPLICATION_ROOT_PATH)
+        self.assertEqual(expected_url, actual_url)


### PR DESCRIPTION
When deploying a Juju Application, a Kubernetes service is spawned bearing the same name as the application. We can use that service name to resolve any addresses between the services. For example, we can use ``http://SDLC_APP_NAME/api`` to access SDLC, instead of ``http://EPHEMERAL_IP:7070/api``.

This way, even if this charm is upgraded or refreshed, we wouldn't have to update Legend Studio with a new service URL.

Alternatively, we can allow users to bring their own host name by using the ``external-hostname`` config option.