### PR TITLE
Adds the enable-tls config option

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -19,6 +19,17 @@ options:
       Must be one of INFO, WARN, DEBUG, or TRACE, or OFF.
 
   ### Nginx Ingress Integrator-related options:
+  enable-tls:
+    type: boolean
+    default: false
+    description: |
+      Boolean representing whether or not this Legend Application endpoint is
+      accessed through HTTPS. Setting this option will not enable TLS on the
+      service itself, and it is meant to be used in conjunction with the
+      tls-secret-name config option on the Nginx Ingress Integrator Charm.
+      Setting this option will cause the Gitlab Callback URLs to be prefixed
+      by HTTPS instead of HTTP, and update Studio to use the HTTPS Service URL.
+
   external-hostname:
     type: string
     default: ""

--- a/src/charm.py
+++ b/src/charm.py
@@ -134,10 +134,13 @@ class LegendSDLCServerCharm(legend_operator_base.BaseFinosLegendCoreServiceCharm
 
     def _get_sdlc_service_url(self):
         svc_hostname = self.model.config["external-hostname"] or self.app.name
+        schema = legend_operator_base.APPLICATION_CONNECTOR_TYPE_HTTP
+        if self.model.config["enable-tls"]:
+            schema = legend_operator_base.APPLICATION_CONNECTOR_TYPE_HTTPS
+
         return SDLC_SERVICE_URL_FORMAT % (
             {
-                # NOTE(aznashwan): we always return the plain HTTP endpoint:
-                "schema": "http",
+                "schema": schema,
                 "host": svc_hostname,
                 "path": APPLICATION_ROOT_PATH,
             }


### PR DESCRIPTION
When the ``enable-tls`` config option is set, the callback URLs set into the gitlab integrator relation and the Service URL set into the Legend Studio will be HTTPS-prefixed.

This config option will not enable TLS on the Legend Application itself, but it is meant to be used in conjunction with the ``tls-secret-name`` config option on the Nginx Ingress Integrator Charm.