### PR TITLE
Adds charm publish github action

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,32 @@
+name: Publish Charm
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  publish-charm:
+    name: Publish Charm to edge
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Check libraries
+        uses: canonical/charming-actions/check-libraries@1.0.0
+        with:
+          credentials: "${{ secrets.CHARMHUB_TOKEN }}"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Upload charm to charmhub
+        # TODO: switch the action to a stable release once the following commits
+        # have been included in a release:
+        # https://github.com/canonical/charming-actions/pull/33
+        # https://github.com/canonical/charming-actions/pull/37
+        uses: canonical/charming-actions/upload-charm@main
+        with:
+          credentials: "${{ secrets.CHARMHUB_TOKEN }}"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          upload-image: "false"
+          channel: "edge"


### PR DESCRIPTION
After a PR merges, a new charm revision will be published on charmhub.io.

This job requires a ``CHARMCRAFT_TOKEN`` secret to be added to the project with the permissions: ``package-manage``, ``package-view-revisions``.

Ref: https://github.com/canonical/charming-actions#usage